### PR TITLE
Allow Userinfo bools to be "true" and "false" strings.

### DIFF
--- a/src/deserializers.rs
+++ b/src/deserializers.rs
@@ -1,0 +1,37 @@
+use serde::Deserializer;
+use de::Visitor;
+use serde::de;
+
+pub fn bool_from_str_or_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+    where D: Deserializer<'de>
+{
+    deserializer.deserialize_any(BoolOrStringVisitor)
+}
+
+struct BoolOrStringVisitor;
+
+impl<'de> Visitor<'de> for BoolOrStringVisitor {
+    type Value = bool;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a boolean or string of \"true\", \"false\".")
+    }
+
+    fn visit_bool<E>(self, value: bool) -> Result<bool, E>
+    where
+        E: de::Error,
+    {
+        Ok(value)
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<bool, E>
+    where
+        E: de::Error,
+    {
+        match value {
+            "true" => Ok(true),
+            "false" => Ok(false),
+            _s => Err(E::custom(format!("Unknown string value: {}", _s))),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,7 @@ mod client;
 mod config;
 mod configurable;
 mod custom_claims;
+mod deserializers;
 mod discovered;
 mod display;
 pub mod error;

--- a/src/userinfo.rs
+++ b/src/userinfo.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 use validator::Validate;
 use validator_derive::Validate;
+use crate::deserializers::bool_from_str_or_bool;
 
 /// The userinfo struct contains all possible userinfo fields regardless of scope. [See spec.](https://openid.net/specs/openid-connect-basic-1_0.html#StandardClaims)
 // TODO is there a way to use claims_supported in config to simplify this struct?
@@ -43,7 +44,7 @@ pub struct Userinfo {
     #[validate(email)]
     /// End-User's preferred e-mail address. Its value MUST conform to the RFC 5322 [RFC5322] addr-spec syntax. The RP MUST NOT rely upon this value being unique, as discussed in Section 5.7.
     pub email: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "bool_from_str_or_bool")]
     /// True if the End-User's e-mail address has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this e-mail address was controlled by the End-User at the time the verification was performed. The means by which an e-mail address is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating.
     pub email_verified: bool,
     // Isn't required to be just male or female
@@ -66,7 +67,7 @@ pub struct Userinfo {
     #[serde(default)]
     /// End-User's preferred telephone number. E.164 [E.164] is RECOMMENDED as the format of this Claim, for example, +1 (425) 555-1212 or +56 (2) 687 2400. If the phone number contains an extension, it is RECOMMENDED that the extension be represented using the RFC 3966 [RFC3966] extension syntax, for example, +1 (604) 555-1234;ext=5678.
     pub phone_number: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "bool_from_str_or_bool")]
     /// True if the End-User's phone number has been verified; otherwise false. When this Claim Value is true, this means that the OP took affirmative steps to ensure that this phone number was controlled by the End-User at the time the verification was performed. The means by which a phone number is verified is context-specific, and dependent upon the trust framework or contractual agreements within which the parties are operating. When true, the phone_number Claim MUST be in E.164 format and any extensions MUST be represented in RFC 3966 format.
     pub phone_number_verified: bool,
     #[serde(default)]


### PR DESCRIPTION
I'm using AWS Cognito, and its `userInfo` endpoint is returning string `"true"` or `"false"` values rather than real bools. This patch allows the crate to contend with that quirk.

I haven't tested this thoroughly (say, by trying providers that aren't AWS). I wanted to offer this proposal and see if it's reasonable. If you'd like me to do more due diligence, please let me know.