### PR TITLE
make IdToken public type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ pub mod biscuit {
     pub use biscuit::*;
 }
 
-type IdToken<T> = Jws<T, Empty>;
+pub type IdToken<T> = Jws<T, Empty>;
 pub type DiscoveredClient = Client<Discovered, StandardClaims>;
 #[cfg(feature = "uma2")]
 pub type DiscoveredUma2Client = Client<uma2::DiscoveredUma2, StandardClaims>;


### PR DESCRIPTION
I have a use case for saving the `IdToken` in a cookie and retrieving it. Making `IdToken` public makes it easier to work with custom claims.