### PR TITLE
Upgrade `biscuit` to 0.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustls = ["reqwest/rustls-tls"]
 lazy_static = "1.4"
 serde_json = { version = "1", default-features = false }
 base64 = "0.13"
-biscuit = "0.5"
+biscuit = "0.6"
 thiserror = "1"
 validator = { version = "0.15", features = ["derive"] }
 


### PR DESCRIPTION
Changelog can be found [here](https://github.com/lawliet89/biscuit/releases/tag/v0.6.0).

This also removes `time 0.1` from the dependency tree, which had some [vulnerabilities](https://rustsec.org/advisories/RUSTSEC-2020-0071).

It looks like a clean upgrade, and I didn't see any of the breaking `biscuit` APIs used in the codebase.