### PR TITLE
Add reqwest_middleware support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ microsoft = []
 uma2 = []
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+middleware = ["reqwest-maybe-middleware/middleware"]
 
 [dependencies]
 lazy_static = "1.4"
@@ -29,6 +30,7 @@ biscuit = "0.6"
 thiserror = "1"
 validator = { version = "0.16", features = ["derive"] }
 mime = "0.3"
+reqwest-maybe-middleware = "0.2.1"
 
 [dependencies.url]
 version = "2"

--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -1,7 +1,7 @@
 use crate::{error::Error, Config, Configurable, Provider};
 use biscuit::jwk::JWKSet;
 use biscuit::Empty;
-use reqwest::Client;
+use reqwest_maybe_middleware::Client;
 use url::Url;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This PR adds `reqwest_middleware` support via feature flag. Should not cause a minor semver bump/breakages.

`request-maybe-middleware` is a short crate that I wrote for this PR to be able to work in a non-verbose non-breaking manor.

The purpose of this integration is for OTLP tracing.