### PR TITLE
Update validator to 0.19, to update idna to ^1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@1.70.0
+    - uses: dtolnay/rust-toolchain@1.71.1
     - name: Build
       run: cargo build
     - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = { version = "1", default-features = false }
 base64 = "0.22"
 biscuit = "0.7"
 thiserror = "1"
-validator = { version = "0.18", features = ["derive"] }
+validator = { version = "0.19", features = ["derive"] }
 mime = "0.3"
 
 [dependencies.url]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["authentication", "authorization", "oauth", "openid", "uma2"]
 license = "Unlicense OR MIT"
 readme = "README.md"
 repository = "https://github.com/kilork/openid"
-rust-version = "1.70"
+rust-version = "1.71.1"
 
 [features]
 default = ["native-tls"]


### PR DESCRIPTION
Upgrades validator to 0.19, to eliminate any chance of using idna < 1. It's not clear whether the vulnerability applies to this library, but upgrading validator does not appear to effect this library either.

## CVSS report:

Vulnerable Library - idna-0.5.0.crate

IDNA (Internationalizing Domain Names in Applications) and Punycode.

Library home page: https://static.crates.io/crates/idna/idna-0.5.0.crate

Path to dependency file: /Cargo.toml

Path to vulnerable library: /Cargo.toml

Dependency Hierarchy:

    openid-0.15.0.crate
        validator-0.18.1.crate
            ❌ idna-0.5.0.crate (Vulnerable Library)

Found in HEAD commit: [adf6187c75ee1de0439ea36e56aa5a17f1d0aeab](https://github.ibm.com/mfg-engineering-test-platform/statit-reverse-proxy/commit/adf6187c75ee1de0439ea36e56aa5a17f1d0aeab)

Found in base branch: main

Vulnerability Details

"idna" 0.5.0 and earlier accepts Punycode labels that do not produce any non-ASCII output, which means that either ASCII labels or the empty root label can be masked such that they appear unequal without IDNA processing or when processed with a different implementation and equal when processed with "idna" 0.5.0 or earlier.
Concretely, "example.org" and "xn--example-.org" become equal after processing by "idna" 0.5.0 or earlier. Also, "example.org.xn--" and "example.org." become equal after processing by "idna" 0.5.0 or earlier.
In applications using "idna" (but not in "idna" itself) this may be able to lead to privilege escalation when host name comparison is part of a privilege check and the behavior is combined with a client that resolves domains with such labels instead of treating them as errors that preclude DNS resolution / URL fetching and with the attacker managing to introduce a DNS entry (and TLS certificate) for an "xn--"-masked name that turns into the name of the target when processed by "idna" 0.5.0 or earlier.
Remedy
Upgrade to "idna" 1.0.3 or later, if depending on "idna" directly, or to "url" 2.5.4 or later, if depending on "idna" via "url". (This issue was fixed in "idna" 1.0.0, but versions earlier than 1.0.3 are not recommended for other reasons.)
When upgrading, please take a moment to read about "alternative Unicode back ends for "idna"" (https://docs.rs/crate/idna_adapter/latest).
If you are using Rust earlier than 1.81 in combination with SQLx 0.8.2 or earlier, please also read an "issue" (https://github.com/servo/rust-url/issues/992) about combining them with "url" 2.5.4 and "idna" 1.0.3.
Additional information
This issue resulted from "idna" 0.5.0 and earlier implementing the UTS 46 specification literally on this point and the specification having this bug. The specification bug has been fixed in "revision 33 of UTS 46" (https://www.unicode.org/reports/tr46/tr46-33.html#Modifications).
Acknowledgements
Thanks to kageshiron for recognizing the security implications of this behavior.

Publish Date: 2024-12-09

URL: [CVE-2024-12224](https://www.mend.io/vulnerability-database/CVE-2024-12224)

CVSS 3 Score Details (4.8)

Base Score Metrics:

    Exploitability Metrics:
        Attack Vector: Network
        Attack Complexity: High
        Privileges Required: None
        User Interaction: None
        Scope: Unchanged
    Impact Metrics:
        Confidentiality Impact: Low
        Integrity Impact: Low
        Availability Impact: None

For more information on CVSS3 Scores, click [here](https://www.first.org/cvss/calculator/3.0).

Suggested Fix

Type: Upgrade version

Origin: https://github.com/advisories/GHSA-h97m-ww89-6jmq

Release Date: 2024-12-09

Fix Resolution: idna - 1.0.0