### PR TITLE
Add rustls-native-roots feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ microsoft = []
 uma2 = []
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls-tls"]
+rustls-native-roots = ["reqwest/rustls-tls-native-roots"]
 
 [dependencies]
 lazy_static = "1.4"

--- a/templates/README.md
+++ b/templates/README.md
@@ -52,6 +52,13 @@ By default we use native tls, if you want to use `rustls`:
 openid = { version = "{{ env_var "OPENID_RUST_MAJOR_VERSION" }}", default-features = false, features = ["rustls"] }
 ```
 
+Alternatively, you can use `rustls` with the platform’s native certificates:
+
+```toml
+[dependencies]
+openid = { version = "{{ env_var "OPENID_RUST_MAJOR_VERSION" }}", default-features = false, features = ["rustls-native-roots"] }
+```
+
 ### Use case: [Warp](https://crates.io/crates/warp) web server with [JHipster](https://www.jhipster.tech/) generated frontend and [Google OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 This example provides only Rust part, assuming just default JHipster frontend settings.


### PR DESCRIPTION
It would be useful to be able to use rustls with platform's native certificates. This will also avoids the MPL-2.0 license that come's with `rustls` feature (because of `webpki-roots` crate).