### PR TITLE
feat: allow credentials_in_body flag to be set for `Discovered`

### DIFF
--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -9,7 +9,7 @@ use crate::{error::Error, Config, Configurable, Provider};
 /// This struct is used to store configuration for a provider that was
 /// discovered using the discovery protocol.
 #[derive(Debug, Clone)]
-pub struct Discovered{
+pub struct Discovered {
     config: Config,
     credentials_in_body: bool,
 }
@@ -36,7 +36,10 @@ impl Configurable for Discovered {
 
 impl From<Config> for Discovered {
     fn from(value: Config) -> Self {
-        Self{config: value, credentials_in_body: false}
+        Self {
+            config: value,
+            credentials_in_body: false,
+        }
     }
 }
 


### PR DESCRIPTION
hiya, we're working on talking to microsoft's entra ID which needs the client_id included in the request body... i see support for this was added in #36, but it doesn't seem like there's any way to turn it on?

so this PR adds a `credentials_in_body` flag to the `Discovered` object (and implements `Provider::credentials_in_body` based on this) to allow this to be configured when required.