### PR TITLE
Remove `rustls-native-certs` feature for compatibility with reqwest 0.13.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,11 @@ rust-version = "1.85"
 
 [features]
 default = ["native-tls", "http2"]
-all = ["microsoft", "uma2", "native-tls", "rustls-native-certs"]
+all = ["microsoft", "uma2", "native-tls"]
 microsoft = []
 uma2 = []
 native-tls = ["reqwest/native-tls"]
 rustls = ["reqwest/rustls"]
-rustls-native-certs = ["reqwest/rustls-native-certs"]
 http2 = ["reqwest/http2"]
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -54,13 +54,6 @@ By default we use native tls, if you want to use `rustls`:
 openid = { version = "0.22", default-features = false, features = ["rustls"] }
 ```
 
-Alternatively, you can use `rustls` with the platform’s native certificates:
-
-```toml
-[dependencies]
-openid = { version = "0.22", default-features = false, features = ["rustls-native-certs"] }
-```
-
 ### Use case: [Warp](https://crates.io/crates/warp) web server with [JHipster](https://www.jhipster.tech/) generated frontend and [Google OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 This example provides only Rust part, assuming just default JHipster frontend settings.

--- a/templates/README.md
+++ b/templates/README.md
@@ -54,13 +54,6 @@ By default we use native tls, if you want to use `rustls`:
 openid = { version = "{{ env_var "CRATE_RUST_MAJOR_VERSION" }}", default-features = false, features = ["rustls"] }
 ```
 
-Alternatively, you can use `rustls` with the platform’s native certificates:
-
-```toml
-[dependencies]
-openid = { version = "{{ env_var "CRATE_RUST_MAJOR_VERSION" }}", default-features = false, features = ["rustls-native-certs"] }
-```
-
 ### Use case: [Warp](https://crates.io/crates/warp) web server with [JHipster](https://www.jhipster.tech/) generated frontend and [Google OpenID Connect](https://developers.google.com/identity/protocols/OpenIDConnect)
 
 This example provides only Rust part, assuming just default JHipster frontend settings.


### PR DESCRIPTION
Reqwest decided to incorporate breaking changes in their 0.13.2 release because they forgot to do that in 0.13.0. https://github.com/seanmonstar/reqwest/issues/2973