### PR TITLE
Make discovered::jwks a public API

### DIFF
--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -62,6 +62,14 @@ pub async fn discover(client: &Client, mut issuer: Url) -> Result<Config, Error>
 
 /// Get the JWK set from the given Url. Errors are either a reqwest error or an
 /// Insecure error if the url isn't https.
+///
+/// This is a low-level helper, useful when working with providers that are not
+/// fully OIDC compliant, e.g. when discovery documents are served from
+/// non-standard locations and the [Client::discover](crate::Client::discover)
+/// flow cannot be used.
+///
+/// The fetched keys are used for ID token signature verification, so only
+/// point this at the `jwks_uri` of a provider you trust.
 pub async fn jwks(client: &Client, url: Url) -> Result<JWKSet<Empty>, Error> {
     let resp = client.get(url).send().await?.error_for_status()?;
     resp.json().await.map_err(Error::from)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@ pub use client::Client;
 pub use config::Config;
 pub use configurable::Configurable;
 pub use custom_claims::CustomClaims;
-pub use discovered::Discovered;
+pub use discovered::{Discovered, jwks};
 pub use display::Display;
 pub use error::{OAuth2Error, OAuth2ErrorCode};
 pub use options::Options;


### PR DESCRIPTION
Closes #88

- re-export `discovered::jwks` at the crate root as `openid::jwks`
- document it as a low-level helper to fetch and initialize the jwks field for providers that are not fully OIDC compliant, e.g. discovery documents served from non-standard locations (QuickBooks sandbox)

Behavior is unchanged. HTTPS enforcement plus an explicit opt-out for development providers is tracked in #89 and implemented in a stacked PR.
