### PR TITLE
Verify-or-error decode without JWKS, discovery issuer pinning

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -210,6 +210,7 @@ impl<C: CompactJson + Claims, P: Provider + Configurable> Client<P, C> {
     ///
     /// # Errors
     ///
+    /// - [Decode::MissingJwks] if no JWK set is configured for this client
     /// - [Decode::MissingKid] if the keyset has multiple keys but the key id on
     ///   the token is missing
     /// - [Decode::MissingKey] if the given key id is not in the key set
@@ -227,12 +228,8 @@ impl<C: CompactJson + Claims, P: Provider + Configurable> Client<P, C> {
             return Ok(());
         }
 
-        if self.jwks.is_none() {
-            return Ok(());
-        }
-
         let Some(jwks) = self.jwks.as_ref() else {
-            return Err(Decode::EmptySet.into());
+            return Err(Decode::MissingJwks.into());
         };
 
         let header = token.unverified_header()?;
@@ -868,8 +865,9 @@ mod tests {
 
     use super::Client;
     use crate::{
-        Config,
+        Config, IdToken, StandardClaims,
         configurable::Configurable,
+        error::{Decode, Error},
         options::Options,
         pkce::{Pkce, PkceSha256},
         provider::Provider,
@@ -902,6 +900,23 @@ mod tests {
         fn config(&self) -> &Config {
             unimplemented!("not needed for auth_url tests")
         }
+    }
+
+    #[test]
+    fn decode_token_without_jwks_is_an_error() {
+        let client: Client<Test, StandardClaims> = Client::new(
+            Test::new(),
+            String::from("client_id"),
+            None::<String>,
+            None::<String>,
+            reqwest::Client::new(),
+            None,
+        );
+        let mut token: IdToken<StandardClaims> = crate::Jws::new_encoded("e30.e30.");
+        assert!(matches!(
+            client.decode_token(&mut token).unwrap_err(),
+            Error::Decode(Decode::MissingJwks)
+        ));
     }
 
     fn test_pkce() -> Option<Pkce> {

--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -72,28 +72,16 @@ pub async fn discover(client: &Client, mut issuer: Url) -> Result<Config, Error>
 /// the requested issuer, as required by [OpenID Connect Discovery
 /// 3.1.2.2](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation).
 ///
-/// A `{tenantid}` segment (also percent encoded as `%7Btenantid%7D`) is
-/// accepted as a template matching any segment value, following the Microsoft
-/// identity platform multi-tenant application convention.
+/// The comparison is exact. Non-compliant providers that return a different
+/// or templated issuer, like the Microsoft multi-tenant `{tenantid}` issuer,
+/// are handled by their provider feature instead.
 ///
 /// # Errors
 ///
 /// - [Error::Validation] if the discovered issuer mismatches the requested
 ///   issuer
 pub fn validate_discovered_issuer(requested: &Url, discovered: &Url) -> Result<(), Error> {
-    let matches = requested == discovered
-        || (requested.scheme() == discovered.scheme()
-            && requested.host() == discovered.host()
-            && requested.port() == discovered.port()
-            && requested
-                .path_segments()
-                .zip(discovered.path_segments())
-                .map(|(requested, discovered)| segments_match(requested, discovered))
-                .unwrap_or_else(|| requested.path() == discovered.path())
-            && requested.query().is_none() == discovered.query().is_none()
-            && requested.fragment().is_none() == discovered.fragment().is_none());
-
-    if matches {
+    if requested == discovered {
         Ok(())
     } else {
         Err(Validation::Mismatch(Mismatch::Issuer {
@@ -102,32 +90,6 @@ pub fn validate_discovered_issuer(requested: &Url, discovered: &Url) -> Result<(
         })
         .into())
     }
-}
-
-/// Checks whether a segment is a `{tenantid}` issuer template placeholder.
-fn is_tenantid_template(segment: &str) -> bool {
-    matches!(
-        segment.to_ascii_lowercase().as_str(),
-        "{tenantid}" | "%7btenantid%7d"
-    )
-}
-
-fn segments_match<'a, I, J>(requested: I, discovered: J) -> bool
-where
-    I: Iterator<Item = &'a str>,
-    J: Iterator<Item = &'a str>,
-{
-    let requested: Vec<&str> = requested.collect();
-    let discovered: Vec<&str> = discovered.collect();
-    requested.len() == discovered.len()
-        && requested
-            .iter()
-            .zip(discovered.iter())
-            .all(|(requested, discovered)| {
-                requested == discovered
-                    || is_tenantid_template(requested)
-                    || is_tenantid_template(discovered)
-            })
 }
 
 /// Get the JWK set from the given Url.
@@ -192,28 +154,23 @@ mod test {
 
     #[test]
     fn validate_discovered_issuer_pins_issuer() {
-        let requested = url("https://login.microsoftonline.com/common/v2.0");
-        let template = url("https://login.microsoftonline.com/%7Btenantid%7D/v2.0");
+        let requested = url("https://example.com/common/v2.0");
         assert!(validate_discovered_issuer(&requested, &requested).is_ok());
-        assert!(validate_discovered_issuer(&requested, &template).is_ok());
-        assert!(validate_discovered_issuer(&template, &requested).is_ok());
 
         assert!(
             validate_discovered_issuer(&requested, &url("https://attacker.example/common/v2.0"))
                 .is_err()
         );
         assert!(
-            validate_discovered_issuer(
-                &requested,
-                &url("https://login.microsoftonline.com/common/v2.0/extra")
-            )
-            .is_err()
+            validate_discovered_issuer(&requested, &url("https://example.com/common/v2.0/extra"))
+                .is_err()
         );
-        let mismatch = validate_discovered_issuer(
-            &requested,
-            &url("http://login.microsoftonline.com/common/v2.0"),
-        )
-        .unwrap_err();
+        assert!(
+            validate_discovered_issuer(&requested, &url("https://example.com/other/v2.0")).is_err()
+        );
+        let mismatch =
+            validate_discovered_issuer(&requested, &url("http://example.com/common/v2.0"))
+                .unwrap_err();
         assert!(mismatch.to_string().contains("issuer"));
     }
 }

--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -2,7 +2,10 @@ use biscuit::{Empty, jwk::JWKSet};
 use reqwest::Client;
 use url::Url;
 
-use crate::{Config, Configurable, Provider, error::Error};
+use crate::{
+    Config, Configurable, Provider,
+    error::{Error, Mismatch, Validation},
+};
 
 /// A discovered provider.
 ///
@@ -50,14 +53,81 @@ impl Discovered {
     }
 }
 
+/// Discovers provider configuration, validating the issuer of the discovered
+/// configuration against the requested issuer.
 pub async fn discover(client: &Client, mut issuer: Url) -> Result<Config, Error> {
+    let requested = issuer.clone();
     issuer
         .path_segments_mut()
         .map_err(|_| Error::CannotBeABase)?
         .extend(&[".well-known", "openid-configuration"]);
 
     let resp = client.get(issuer).send().await?.error_for_status()?;
-    resp.json().await.map_err(Error::from)
+    let config: Config = resp.json().await.map_err(Error::from)?;
+    validate_discovered_issuer(&requested, &config.issuer)?;
+    Ok(config)
+}
+
+/// Validates that the issuer of the discovered provider configuration matches
+/// the requested issuer, as required by [OpenID Connect Discovery
+/// 3.1.2.2](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationValidation).
+///
+/// A `{tenantid}` segment (also percent encoded as `%7Btenantid%7D`) is
+/// accepted as a template matching any segment value, following the Microsoft
+/// identity platform multi-tenant application convention.
+///
+/// # Errors
+///
+/// - [Error::Validation] if the discovered issuer mismatches the requested
+///   issuer
+pub fn validate_discovered_issuer(requested: &Url, discovered: &Url) -> Result<(), Error> {
+    let matches = requested == discovered
+        || (requested.scheme() == discovered.scheme()
+            && requested.host() == discovered.host()
+            && requested.port() == discovered.port()
+            && requested
+                .path_segments()
+                .zip(discovered.path_segments())
+                .map(|(requested, discovered)| segments_match(requested, discovered))
+                .unwrap_or_else(|| requested.path() == discovered.path())
+            && requested.query().is_none() == discovered.query().is_none()
+            && requested.fragment().is_none() == discovered.fragment().is_none());
+
+    if matches {
+        Ok(())
+    } else {
+        Err(Validation::Mismatch(Mismatch::Issuer {
+            expected: requested.to_string(),
+            actual: discovered.to_string(),
+        })
+        .into())
+    }
+}
+
+/// Checks whether a segment is a `{tenantid}` issuer template placeholder.
+fn is_tenantid_template(segment: &str) -> bool {
+    matches!(
+        segment.to_ascii_lowercase().as_str(),
+        "{tenantid}" | "%7btenantid%7d"
+    )
+}
+
+fn segments_match<'a, I, J>(requested: I, discovered: J) -> bool
+where
+    I: Iterator<Item = &'a str>,
+    J: Iterator<Item = &'a str>,
+{
+    let requested: Vec<&str> = requested.collect();
+    let discovered: Vec<&str> = discovered.collect();
+    requested.len() == discovered.len()
+        && requested
+            .iter()
+            .zip(discovered.iter())
+            .all(|(requested, discovered)| {
+                requested == discovered
+                    || is_tenantid_template(requested)
+                    || is_tenantid_template(discovered)
+            })
 }
 
 /// Get the JWK set from the given Url.
@@ -118,5 +188,32 @@ mod test {
     fn validate_https_rejects_http_and_accepts_https() {
         assert!(validate_https(&url("http://localhost:8080/realms/test")).is_err());
         assert!(validate_https(&url("https://example.com/jwks")).is_ok());
+    }
+
+    #[test]
+    fn validate_discovered_issuer_pins_issuer() {
+        let requested = url("https://login.microsoftonline.com/common/v2.0");
+        let template = url("https://login.microsoftonline.com/%7Btenantid%7D/v2.0");
+        assert!(validate_discovered_issuer(&requested, &requested).is_ok());
+        assert!(validate_discovered_issuer(&requested, &template).is_ok());
+        assert!(validate_discovered_issuer(&template, &requested).is_ok());
+
+        assert!(
+            validate_discovered_issuer(&requested, &url("https://attacker.example/common/v2.0"))
+                .is_err()
+        );
+        assert!(
+            validate_discovered_issuer(
+                &requested,
+                &url("https://login.microsoftonline.com/common/v2.0/extra")
+            )
+            .is_err()
+        );
+        let mismatch = validate_discovered_issuer(
+            &requested,
+            &url("http://login.microsoftonline.com/common/v2.0"),
+        )
+        .unwrap_err();
+        assert!(mismatch.to_string().contains("issuer"));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -225,6 +225,9 @@ pub enum Decode {
     /// No support for Octet key pair yet.
     #[error("No support for Octet key pair yet")]
     UnsupportedOctetKeyPair,
+    /// No JWK set configured to verify token signature.
+    #[error("No JWK set configured to verify token signature")]
+    MissingJwks,
 }
 
 /// Validation failure related to mismatch of values, missing values or expired

--- a/src/uma2/discovered.rs
+++ b/src/uma2/discovered.rs
@@ -77,11 +77,14 @@ impl<C: CompactJson + Claims> Client<DiscoveredUma2, C> {
 }
 
 pub async fn discover_uma2(client: &reqwest::Client, issuer: &Url) -> Result<Uma2Config, Error> {
+    let requested = issuer.clone();
     let mut issuer = issuer.clone();
     issuer
         .path_segments_mut()
         .map_err(|_| Error::CannotBeABase)?
         .extend(&[".well-known", "uma2-configuration"]);
     let resp = client.get(issuer).send().await?;
-    resp.json().await.map_err(Error::from)
+    let config: Uma2Config = resp.json().await.map_err(Error::from)?;
+    crate::discovered::validate_discovered_issuer(&requested, &config.config.issuer)?;
+    Ok(config)
 }


### PR DESCRIPTION
Implements the first two findings of #92:

1. `Client::decode_token` returns `Ok` for unverified tokens when `client.jwks == None` — replaced with a new `Decode::MissingJwks` error. Non-breaking in practice: `validate_token`/`authenticate` already failed afterwards at `payload()`.
2. `discovered::discover` now pins `config.issuer` to the requested issuer (OIDC Discovery 3.1.2.2) — **exact match**. Same check in UMA2 discovery.

Provider-specific non-compliance stays in provider features, like Microsoft's issuer-skipping `microsoft::authenticate` today: the `{tenantid}` template issuer is deliberately **not** special-cased in generic discovery. Multi-tenant Microsoft apps:
- keep working through the `microsoft` feature (its `validate_token` skips the issuer check),
- or assemble the client manually (fetch config yourself → `Discovered::from`) — the same path used for other non-compliant providers in #88.

Follow-up for a *proper* Microsoft multi-tenant solution (issuer template vs `tid` claim instead of skipping the check entirely) is tracked in #70/#7.

Remaining item of #92: https enforcement for token/userinfo/introspection + per-client opt-out design — will follow in a stacked PR.
