### PR TITLE
Enforce response size limits (1 MiB) for provider JSON

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -424,7 +424,8 @@ impl<C: CompactJson + Claims, P: Provider + Configurable> Client<P, C> {
 
                 let info: U = match (mime_type.type_(), mime_type.subtype().as_str()) {
                     (mime::APPLICATION, "json") => {
-                        let info_value: Value = response.json().await?;
+                        let info_value: Value =
+                            crate::http::json(response).await.map_err(Error::from)?;
                         if info_value.get("error").is_some() {
                             let oauth2_error: OAuth2Error = serde_json::from_value(info_value)?;
                             return Err(Error::ClientError(oauth2_error.into()));
@@ -527,7 +528,8 @@ impl<C: CompactJson + Claims, P: Provider + Configurable> Client<P, C> {
                 let info: TokenIntrospection<I> =
                     match (mime_type.type_(), mime_type.subtype().as_str()) {
                         (mime::APPLICATION, "json") => {
-                            let info_value: Value = response.json().await?;
+                            let info_value: Value =
+                                crate::http::json(response).await.map_err(Error::from)?;
                             if info_value.get("error").is_some() {
                                 let oauth2_error: OAuth2Error = serde_json::from_value(info_value)?;
                                 return Err(Error::ClientError(oauth2_error.into()));
@@ -819,7 +821,7 @@ where
     }
 
     async fn post_token(&self, body: String) -> Result<Value, ClientError> {
-        let json = self
+        let response = self
             .http_client
             .post(self.provider.token_uri().clone())
             .basic_auth(&self.client_id, self.client_secret.as_ref())
@@ -827,9 +829,9 @@ where
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .body(body)
             .send()
-            .await?
-            .json::<Value>()
             .await?;
+
+        let json: Value = crate::http::json(response).await?;
 
         let error: Result<OAuth2Error, _> = serde_json::from_value(json.clone());
 

--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -99,6 +99,49 @@ pub async fn jwks_insecure(client: &Client, url: Url) -> Result<JWKSet<Empty>, E
     crate::http::json(resp).await.map_err(Error::from)
 }
 
+/// Get the JWK set from the given Url, enforcing the https scheme and a
+/// custom response size limit.
+///
+/// Same as [jwks], but accepts a maximum response size, for providers whose
+/// JWK set exceeds the default limit of 1 MiB (providers with many signing
+/// keys). Use [jwks_insecure_with_max_size] to allow non-https urls.
+///
+/// A `max_response_size` of [usize::MAX] disables the limit.
+///
+/// # Errors
+///
+/// - [Error::Insecure] if the url isn't https
+/// - [Error::ClientError](`ClientError::ResponseTooBig`) if the response
+///   exceeds `max_response_size`
+/// - reqwest errors
+/// - JSON deserialization errors
+pub async fn jwks_with_max_size(
+    client: &Client,
+    url: Url,
+    max_response_size: usize,
+) -> Result<JWKSet<Empty>, Error> {
+    validate_https(&url)?;
+    jwks_insecure_with_max_size(client, url, max_response_size).await
+}
+
+/// Get the JWK set from the given Url with a custom response size limit and
+/// without https enforcement.
+///
+/// Same as [jwks_insecure], but accepts a maximum response size, for
+/// providers whose JWK set exceeds the default limit of 1 MiB. The fetched
+/// keys are used for ID token signature verification as well, so use it only
+/// with providers you trust.
+pub async fn jwks_insecure_with_max_size(
+    client: &Client,
+    url: Url,
+    max_response_size: usize,
+) -> Result<JWKSet<Empty>, Error> {
+    let resp = client.get(url).send().await?.error_for_status()?;
+    crate::http::json_with_limit(resp, max_response_size)
+        .await
+        .map_err(Error::from)
+}
+
 /// Errors if the url is not https.
 fn validate_https(url: &Url) -> Result<(), Error> {
     if url.scheme() != "https" {

--- a/src/discovered.rs
+++ b/src/discovered.rs
@@ -57,7 +57,8 @@ pub async fn discover(client: &Client, mut issuer: Url) -> Result<Config, Error>
         .extend(&[".well-known", "openid-configuration"]);
 
     let resp = client.get(issuer).send().await?.error_for_status()?;
-    resp.json().await.map_err(Error::from)
+    let config: Config = crate::http::json(resp).await.map_err(Error::from)?;
+    Ok(config)
 }
 
 /// Get the JWK set from the given Url.
@@ -95,7 +96,7 @@ pub async fn jwks(client: &Client, url: Url) -> Result<JWKSet<Empty>, Error> {
 /// - JSON deserialization errors
 pub async fn jwks_insecure(client: &Client, url: Url) -> Result<JWKSet<Empty>, Error> {
     let resp = client.get(url).send().await?.error_for_status()?;
-    resp.json().await.map_err(Error::from)
+    crate::http::json(resp).await.map_err(Error::from)
 }
 
 /// Errors if the url is not https.

--- a/src/error.rs
+++ b/src/error.rs
@@ -113,6 +113,14 @@ pub enum ClientError {
     /// UMA2 error.
     #[cfg(feature = "uma2")]
     Uma2(Uma2Error),
+
+    /// Response exceeds the maximum allowed size.
+    ResponseTooBig {
+        /// Actual response size.
+        size: usize,
+        /// Maximum allowed response size.
+        max: usize,
+    },
 }
 
 impl fmt::Display for ClientError {
@@ -125,6 +133,12 @@ impl fmt::Display for ClientError {
             ClientError::OAuth2(ref err) => write!(f, "{err}"),
             #[cfg(feature = "uma2")]
             ClientError::Uma2(ref err) => write!(f, "{err}"),
+            ClientError::ResponseTooBig { size, max } => {
+                write!(
+                    f,
+                    "Response of {size} bytes exceeds maximum allowed size of {max} bytes"
+                )
+            }
         }
     }
 }
@@ -139,6 +153,7 @@ impl error::Error for ClientError {
             ClientError::OAuth2(ref err) => Some(err),
             #[cfg(feature = "uma2")]
             ClientError::Uma2(ref err) => Some(err),
+            ClientError::ResponseTooBig { .. } => None,
         }
     }
 }
@@ -202,6 +217,14 @@ pub enum Error {
     /// Path segments in url is cannot-be-a-base.
     #[error("Url: Path segments is cannot-be-a-base")]
     CannotBeABase,
+    /// Response exceeds the maximum allowed size.
+    #[error("Response of {size} bytes exceeds maximum allowed size of {max} bytes")]
+    ResponseTooBig {
+        /// Actual response size.
+        size: usize,
+        /// Maximum allowed response size.
+        max: usize,
+    },
     /// Client side error.
     #[error(transparent)]
     ClientError(#[from] ClientError),

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,30 @@
+use serde::de::DeserializeOwned;
+
+use crate::error::ClientError;
+
+/// Maximum accepted response body size for provider documents and payloads.
+///
+/// See issue [#95](https://github.com/kilork/openid/issues/95): provider
+/// responses are untrusted, unbounded reads should not cause memory pressure.
+pub(crate) const MAX_RESPONSE_SIZE: usize = 1024 * 1024;
+
+/// Reads a response body and deserializes JSON, enforcing a size limit.
+///
+/// # Errors
+///
+/// - [ClientError::ResponseTooBig] if the response is larger than
+///   [MAX_RESPONSE_SIZE]
+/// - [ClientError::Reqwest] if reading the response fails
+/// - [ClientError::Json] if the response is not a valid `T`
+pub(crate) async fn json<T: DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T, ClientError> {
+    let bytes = response.bytes().await?;
+    if bytes.len() > MAX_RESPONSE_SIZE {
+        return Err(ClientError::ResponseTooBig {
+            size: bytes.len(),
+            max: MAX_RESPONSE_SIZE,
+        });
+    }
+    serde_json::from_slice(&bytes).map_err(ClientError::Json)
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -19,11 +19,25 @@ pub(crate) const MAX_RESPONSE_SIZE: usize = 1024 * 1024;
 pub(crate) async fn json<T: DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T, ClientError> {
+    json_with_limit(response, MAX_RESPONSE_SIZE).await
+}
+
+/// Reads a response body and deserializes JSON, enforcing a size limit.
+///
+/// # Errors
+///
+/// - [ClientError::ResponseTooBig] if the response is larger than `max`
+/// - [ClientError::Reqwest] if reading the response fails
+/// - [ClientError::Json] if the response is not a valid `T`
+pub(crate) async fn json_with_limit<T: DeserializeOwned>(
+    response: reqwest::Response,
+    max: usize,
+) -> Result<T, ClientError> {
     let bytes = response.bytes().await?;
-    if bytes.len() > MAX_RESPONSE_SIZE {
+    if bytes.len() > max {
         return Err(ClientError::ResponseTooBig {
             size: bytes.len(),
-            max: MAX_RESPONSE_SIZE,
+            max,
         });
     }
     serde_json::from_slice(&bytes).map_err(ClientError::Json)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod deserializers;
 mod discovered;
 mod display;
 pub mod error;
+mod http;
 mod options;
 pub mod pkce;
 mod prompt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,9 @@ pub use client::Client;
 pub use config::Config;
 pub use configurable::Configurable;
 pub use custom_claims::CustomClaims;
-pub use discovered::{Discovered, jwks, jwks_insecure};
+pub use discovered::{
+    Discovered, jwks, jwks_insecure, jwks_insecure_with_max_size, jwks_with_max_size,
+};
 pub use display::Display;
 pub use error::{OAuth2Error, OAuth2ErrorCode};
 pub use options::Options;

--- a/src/uma2/discovered.rs
+++ b/src/uma2/discovered.rs
@@ -83,5 +83,6 @@ pub async fn discover_uma2(client: &reqwest::Client, issuer: &Url) -> Result<Uma
         .map_err(|_| Error::CannotBeABase)?
         .extend(&[".well-known", "uma2-configuration"]);
     let resp = client.get(issuer).send().await?;
-    resp.json().await.map_err(Error::from)
+    let config: Uma2Config = crate::http::json(resp).await.map_err(Error::from)?;
+    Ok(config)
 }

--- a/src/uma2/rpt.rs
+++ b/src/uma2/rpt.rs
@@ -143,16 +143,16 @@ where
             Uma2AuthenticationMethod::Bearer => format!("Bearer {:}", token),
         };
 
-        let json = self
+        let response = self
             .http_client
             .post(self.provider.token_uri().clone())
             .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
             .header(AUTHORIZATION, auth_method.as_str())
             .body(body)
             .send()
-            .await?
-            .json::<Value>()
             .await?;
+
+        let json: Value = crate::http::json(response).await?;
 
         let error: Result<OAuth2Error, _> = serde_json::from_value(json.clone());
 
@@ -192,16 +192,16 @@ where
             return Err(ClientError::Uma2(NoPermissionsEndpoint));
         };
 
-        let json = self
+        let response = self
             .http_client
             .post(url)
             .header(CONTENT_TYPE, "application/json")
             .header(AUTHORIZATION, format!("Bearer {:}", pat_token))
             .json(&requests)
             .send()
-            .await?
-            .json::<Value>()
             .await?;
+
+        let json: Value = crate::http::json(response).await?;
 
         let error: Result<OAuth2Error, _> = serde_json::from_value(json.clone());
 


### PR DESCRIPTION
Fixes #95

- Shared internal `crate::http::json` helper: reads body as bytes, errors `ClientError::ResponseTooBig` above the limit before parsing.
- Wired into discovery config, JWKS, token requests (OIDC + UMA2), userinfo, introspection.
- **Configurable limit**: default is 1 MiB (`crate::http::MAX_RESPONSE_SIZE`); for providers whose JWK set is larger (many signing keys), new sibling methods `jwks_with_max_size` and `jwks_insecure_with_max_size` accept a custom limit (`usize::MAX` disables it) — same sibling pattern as #89. Other fetches keep the default; the limit inside the `Client::discover` flow stays at the default until the per-client settings from #92 part 3 land.
- `Error`-returning call sites surface it as `Error::ClientError(ResponseTooBig)` (transparent).
